### PR TITLE
Add an OtherCommitters class

### DIFF
--- a/lib/close_old_pull_requests.rb
+++ b/lib/close_old_pull_requests.rb
@@ -3,6 +3,8 @@ require 'close_old_pull_requests/version'
 module CloseOldPullRequests
   PullRequest = Struct.new(:number, :superseded_by)
 
+  # Finds the outdated pull requests in a list of pull requests that comes
+  # back from the GitHub API.
   class Finder
     attr_reader :pull_requests
 
@@ -16,6 +18,28 @@ module CloseOldPullRequests
         new_pr = PullRequest.new(pulls.first[:number])
         pulls.drop(1).map { |p| PullRequest.new(p[:number], new_pr) }
       end.compact.flatten
+    end
+  end
+
+  # Determines if there have been any non-bot commits on a pull request.
+  class OtherCommitters
+    attr_reader :commits, :primary_login
+
+    def initialize(commits:, primary_login:)
+      @commits = commits
+      @primary_login = primary_login
+    end
+
+    def author_logins
+      commits.map { |c| c[:author][:login] }.uniq.reject { |l| l == primary_login }
+    end
+
+    def mentions
+      author_logins.map { |c| "@#{c}" }.join(', ')
+    end
+
+    def empty?
+      author_logins.empty?
     end
   end
 end

--- a/test/close_old_pull_requests_test.rb
+++ b/test/close_old_pull_requests_test.rb
@@ -17,4 +17,35 @@ describe CloseOldPullRequests do
       outdated_pr.superseded_by.number.must_equal 100
     end
   end
+
+  describe CloseOldPullRequests::OtherCommitters do
+    it 'represents a single committer' do
+      commits = [
+        { author: { login: 'everypoliticianbot' } },
+        { author: { login: 'everypoliticianbot' } },
+      ]
+      other_committers = CloseOldPullRequests::OtherCommitters.new(
+        commits: commits,
+        primary_login: 'everypoliticianbot'
+      )
+      other_committers.author_logins.must_equal []
+      other_committers.empty?.must_equal true
+      other_committers.mentions.must_equal ''
+    end
+
+    it 'represents multiple committers' do
+      commits = [
+        { author: { login: 'everypoliticianbot' } },
+        { author: { login: 'tmtmtmtm' } },
+        { author: { login: 'chrismytton' } },
+      ]
+      other_committers = CloseOldPullRequests::OtherCommitters.new(
+        commits: commits,
+        primary_login: 'everypoliticianbot'
+      )
+      other_committers.author_logins.must_equal ['tmtmtmtm', 'chrismytton']
+      other_committers.mentions.must_equal '@tmtmtmtm, @chrismytton'
+      other_committers.empty?.must_equal false
+    end
+  end
 end


### PR DESCRIPTION
This class represents the committer or committers for a series of
commits. It will be used to determine whether a pull request has had any
human interaction, or whether it is just a bot's pull request. If it's
just a bot then it can close the pull request if there's a newer one,
otherwise it needs to mention the humans that are involved to see if the
pull request is still relevant.
