### PR TITLE
Prevent duplicate comments on a pull request

### DIFF
--- a/lib/close_old_pull_requests.rb
+++ b/lib/close_old_pull_requests.rb
@@ -10,7 +10,7 @@ module CloseOldPullRequests
     github = Octokit::Client.new
     github.access_token = access_token
     Cleaner.new(github).clean_old_pull_requests
-  rescue Octokit::Unauthorized => error
+  rescue Octokit::Unauthorized
     abort 'Please set GITHUB_ACCESS_TOKEN in the environment and try again'
   end
 

--- a/lib/close_old_pull_requests.rb
+++ b/lib/close_old_pull_requests.rb
@@ -69,18 +69,23 @@ module CloseOldPullRequests
         )
         if other_committers.empty? # The only commits were by @everypoliticianbot
           message = "This Pull Request has been superseded by ##{pull_request.superseded_by.number}"
-          github.add_comment(everypolitician_data_repo, pull_request.number, message)
+          add_comment(pull_request.number, message)
           github.close_pull_request(everypolitician_data_repo, pull_request.number)
         else # There are human commits
           message = "This Pull Request has been superseded by ##{pull_request.superseded_by.number}" \
             " but there are non-bot commits.\n\n" \
             "#{other_committers.mentions} is this pull request still needed?"
-          github.add_comment(everypolitician_data_repo, pull_request.number, message)
+          add_comment(pull_request.number, message)
         end
       end
     end
 
     private
+
+    def add_comment(number, message)
+      return if github.issue_comments(everypolitician_data_repo, number).map(&:body).include?(message)
+      github.add_comment(everypolitician_data_repo, number, message)
+    end
 
     def pull_requests
       @pull_requests ||= github.pull_requests(everypolitician_data_repo)

--- a/test/close_old_pull_requests_test.rb
+++ b/test/close_old_pull_requests_test.rb
@@ -60,6 +60,7 @@ describe CloseOldPullRequests do
     before do
       github.expect :user, GitHubUser.new('everypoliticianbot')
       github.expect :pull_requests, pull_requests, [everypolitician_data]
+      github.expect :issue_comments, [], [everypolitician_data, 42]
     end
 
     after { github.verify }


### PR DESCRIPTION
This ensures that there are no double posts of comments on issues that
have had human interactions and therefore don't get closed immediately.
