### PR TITLE
Change the interface of Finder#outdated

### DIFF
--- a/lib/close_old_pull_requests.rb
+++ b/lib/close_old_pull_requests.rb
@@ -101,7 +101,7 @@ module CloseOldPullRequests
         )
         summary = Summary.new(
           new_pull_request_number: new_pull_request.number,
-          other_committers: other_committers
+          other_committers:        other_committers
         )
         add_comment(pull_request.number, summary.message)
         github.close_pull_request(everypolitician_data_repo, pull_request.number) if summary.can_be_closed?

--- a/lib/close_old_pull_requests.rb
+++ b/lib/close_old_pull_requests.rb
@@ -59,6 +59,31 @@ module CloseOldPullRequests
     end
   end
 
+  class Summary
+    def initialize(new_pull_request_number:, other_committers:)
+      @new_pull_request_number = new_pull_request_number
+      @other_committers = other_committers
+    end
+
+    def message
+      if can_be_closed?
+        "This Pull Request has been superseded by ##{new_pull_request_number}"
+      else # There are human commits
+        "This Pull Request has been superseded by ##{new_pull_request_number}" \
+          " but there are non-bot commits.\n\n" \
+          "#{other_committers.mentions} is this pull request still needed?"
+      end
+    end
+
+    def can_be_closed?
+      other_committers.empty?
+    end
+
+    private
+
+    attr_reader :new_pull_request_number, :other_committers
+  end
+
   class Cleaner
     PRIMARY_LOGIN = 'everypoliticianbot'.freeze
 
@@ -74,16 +99,12 @@ module CloseOldPullRequests
           commits:       pull_request_commits(pull_request.number),
           primary_login: PRIMARY_LOGIN
         )
-        if other_committers.empty? # The only commits were by @everypoliticianbot
-          message = "This Pull Request has been superseded by ##{new_pull_request.number}"
-          add_comment(pull_request.number, message)
-          github.close_pull_request(everypolitician_data_repo, pull_request.number)
-        else # There are human commits
-          message = "This Pull Request has been superseded by ##{new_pull_request.number}" \
-            " but there are non-bot commits.\n\n" \
-            "#{other_committers.mentions} is this pull request still needed?"
-          add_comment(pull_request.number, message)
-        end
+        summary = Summary.new(
+          new_pull_request_number: new_pull_request.number,
+          other_committers: other_committers
+        )
+        add_comment(pull_request.number, summary.message)
+        github.close_pull_request(everypolitician_data_repo, pull_request.number) if summary.can_be_closed?
       end
     end
 

--- a/lib/close_old_pull_requests.rb
+++ b/lib/close_old_pull_requests.rb
@@ -4,8 +4,6 @@ require 'octokit'
 Octokit.auto_paginate = true
 
 module CloseOldPullRequests
-  PullRequest = Struct.new(:number, :superseded_by)
-
   def self.clean(access_token: ENV['GITHUB_ACCESS_TOKEN'])
     github = Octokit::Client.new
     github.access_token = access_token
@@ -24,11 +22,11 @@ module CloseOldPullRequests
     end
 
     def outdated
-      pull_requests.group_by { |pr| [pr[:title], pr[:user][:login]] }.values.map do |pulls|
+      pull_requests.group_by { |pr| [pr[:title], pr[:user][:login]] }.values.flat_map do |pulls|
         pulls = pulls.sort_by { |p| p[:created_at] }.reverse
-        new_pr = PullRequest.new(pulls.first[:number])
-        pulls.drop(1).map { |p| PullRequest.new(p[:number], new_pr) }
-      end.compact.flatten
+        new_pr = pulls.first
+        pulls.drop(1).map { |pull| [pull, new_pr] }
+      end.to_h
     end
   end
 
@@ -64,20 +62,20 @@ module CloseOldPullRequests
     end
 
     def clean_old_pull_requests
-      Finder.new(pull_requests).outdated.each do |pull_request|
+      Finder.new(pull_requests).outdated.each do |pull_request, new_pull_request|
         other_committers = OtherCommitters.new(
-          commits:       pull_request_commits(pull_request.number),
+          commits:       pull_request_commits(pull_request[:number]),
           primary_login: PRIMARY_LOGIN
         )
         if other_committers.empty? # The only commits were by @everypoliticianbot
-          message = "This Pull Request has been superseded by ##{pull_request.superseded_by.number}"
-          add_comment(pull_request.number, message)
-          github.close_pull_request(everypolitician_data_repo, pull_request.number)
+          message = "This Pull Request has been superseded by ##{new_pull_request[:number]}"
+          add_comment(pull_request[:number], message)
+          github.close_pull_request(everypolitician_data_repo, pull_request[:number])
         else # There are human commits
-          message = "This Pull Request has been superseded by ##{pull_request.superseded_by.number}" \
+          message = "This Pull Request has been superseded by ##{new_pull_request[:number]}" \
             " but there are non-bot commits.\n\n" \
             "#{other_committers.mentions} is this pull request still needed?"
-          add_comment(pull_request.number, message)
+          add_comment(pull_request[:number], message)
         end
       end
     end

--- a/lib/close_old_pull_requests.rb
+++ b/lib/close_old_pull_requests.rb
@@ -23,6 +23,11 @@ module CloseOldPullRequests
       @pull_requests = pull_requests
     end
 
+    # Sorts through the `pull_requests` and returns a Hash where the key is the
+    # pull request that is now considered outdated and the value is the pull
+    # request that supersedes it.
+    #
+    # @return [Hash] old to new pull request mapping
     def outdated
       pull_requests.group_by { |pr| [pr[:title], pr[:user][:login]] }.values.flat_map do |pulls|
         pulls = pulls.sort_by { |p| p[:created_at] }.reverse.map { |pr| PullRequest.new(pr[:number]) }

--- a/lib/close_old_pull_requests.rb
+++ b/lib/close_old_pull_requests.rb
@@ -26,8 +26,8 @@ module CloseOldPullRequests
     def outdated
       pull_requests.group_by { |pr| [pr[:title], pr[:user][:login]] }.values.flat_map do |pulls|
         pulls = pulls.sort_by { |p| p[:created_at] }.reverse.map { |pr| PullRequest.new(pr[:number]) }
-        new_pr = pulls.first
-        pulls.drop(1).map { |pull| [pull, new_pr] }
+        new_pr = pulls.shift
+        pulls.map { |pull| [pull, new_pr] }
       end.to_h
     end
   end

--- a/test/close_old_pull_requests_test.rb
+++ b/test/close_old_pull_requests_test.rb
@@ -103,13 +103,17 @@ describe CloseOldPullRequests do
   end
 
   describe CloseOldPullRequests::Summary do
-    OtherCommittersMock = Struct.new(:mentions, :empty) { def empty?; empty; end }
+    OtherCommittersMock = Struct.new(:mentions, :empty) do
+      def empty?
+        empty
+      end
+    end
 
     describe 'with no other committers' do
       subject do
         CloseOldPullRequests::Summary.new(
           new_pull_request_number: 42,
-          other_committers: OtherCommittersMock.new('', true)
+          other_committers:        OtherCommittersMock.new('', true)
         )
       end
 
@@ -126,7 +130,7 @@ describe CloseOldPullRequests do
       subject do
         CloseOldPullRequests::Summary.new(
           new_pull_request_number: 42,
-          other_committers: OtherCommittersMock.new('@example, @mention', false)
+          other_committers:        OtherCommittersMock.new('@example, @mention', false)
         )
       end
 

--- a/test/close_old_pull_requests_test.rb
+++ b/test/close_old_pull_requests_test.rb
@@ -12,8 +12,8 @@ describe CloseOldPullRequests do
   describe CloseOldPullRequests::Finder do
     it 'returns a list of outdated pull requests' do
       outdated_pr, new_pr = CloseOldPullRequests::Finder.new(pull_requests).outdated.first
-      outdated_pr.must_equal outdated_pull_request
-      new_pr.must_equal new_pull_request
+      outdated_pr.number.must_equal 42
+      new_pr.number.must_equal 100
     end
   end
 

--- a/test/close_old_pull_requests_test.rb
+++ b/test/close_old_pull_requests_test.rb
@@ -101,4 +101,43 @@ describe CloseOldPullRequests do
       end
     end
   end
+
+  describe CloseOldPullRequests::Summary do
+    OtherCommittersMock = Struct.new(:mentions, :empty) { def empty?; empty; end }
+
+    describe 'with no other committers' do
+      subject do
+        CloseOldPullRequests::Summary.new(
+          new_pull_request_number: 42,
+          other_committers: OtherCommittersMock.new('', true)
+        )
+      end
+
+      it 'leaves a message pointing to the new pull request' do
+        subject.message.must_equal 'This Pull Request has been superseded by #42'
+      end
+
+      it 'can close the pull request' do
+        subject.can_be_closed?.must_equal true
+      end
+    end
+
+    describe 'with other committers' do
+      subject do
+        CloseOldPullRequests::Summary.new(
+          new_pull_request_number: 42,
+          other_committers: OtherCommittersMock.new('@example, @mention', false)
+        )
+      end
+
+      it 'leaves a message pointing to the new pull request' do
+        subject.message.must_equal "This Pull Request has been superseded by #42 but there are non-bot commits.\n\n" \
+          '@example, @mention is this pull request still needed?'
+      end
+
+      it "can't close the pull request" do
+        subject.can_be_closed?.must_equal false
+      end
+    end
+  end
 end

--- a/test/close_old_pull_requests_test.rb
+++ b/test/close_old_pull_requests_test.rb
@@ -5,18 +5,15 @@ describe CloseOldPullRequests do
     refute_nil ::CloseOldPullRequests::VERSION
   end
 
-  let(:pull_requests) do
-    [
-      { number: 42, title: 'Test', created_at: '2016-09-05T18:25:42Z', user: { login: 'everypoliticianbot' } },
-      { number: 100, title: 'Test', created_at: '2016-09-07T12:00:00Z', user: { login: 'everypoliticianbot' } },
-    ]
-  end
+  let(:outdated_pull_request) { { number: 42, title: 'Test', created_at: '2016-09-05T18:25:42Z', user: { login: 'everypoliticianbot' } } }
+  let(:new_pull_request) { { number: 100, title: 'Test', created_at: '2016-09-07T12:00:00Z', user: { login: 'everypoliticianbot' } } }
+  let(:pull_requests) { [outdated_pull_request, new_pull_request] }
 
   describe CloseOldPullRequests::Finder do
     it 'returns a list of outdated pull requests' do
-      outdated_pr = CloseOldPullRequests::Finder.new(pull_requests).outdated.first
-      outdated_pr.number.must_equal 42
-      outdated_pr.superseded_by.number.must_equal 100
+      outdated_pr, new_pr = CloseOldPullRequests::Finder.new(pull_requests).outdated.first
+      outdated_pr.must_equal outdated_pull_request
+      new_pr.must_equal new_pull_request
     end
   end
 


### PR DESCRIPTION
This changes `Finder#outdated` to returns a hash rather than an array,
which allows us to have the key be the old pull request, and the value
be the new pull request.

Fixes #12 
