### PR TITLE
Use the Rakefile to control which tasks are run on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,3 @@ rvm:
   - 2.2.5
   - 2.3.1
 before_install: gem install bundler -v 1.12.5
-script: bundle exec rake test rubocop

--- a/Rakefile
+++ b/Rakefile
@@ -7,7 +7,7 @@ Rake::TestTask.new(:test) do |t|
   t.test_files = FileList['test/**/*_test.rb']
 end
 
-task default: :test
-
 require 'rubocop/rake_task'
 RuboCop::RakeTask.new
+
+task default: %w(test rubocop)


### PR DESCRIPTION
This change moves the list of tasks that are run on Travis into the
`:default` rake target. This means that when you're developing locally
running `bundle exec rake` will run the exact same scripts that Travis
will, making it harder to accidentally break the build.

Part of https://github.com/everypolitician/everypolitician/issues/516
