### PR TITLE
Test on the latest patch versions of supported rubies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.1.10
-  - 2.2.5
-  - 2.3.1
+  - 2.1
+  - 2.2
+  - 2.3
 before_install: gem install bundler -v 1.12.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,5 @@ language: ruby
 rvm:
   - 2.1
   - 2.2
-  - 2.3
+  - 2.3.1
 before_install: gem install bundler -v 1.12.5


### PR DESCRIPTION
Rather than explicitly specifying a patch version of the rubies we want to test against in `.travis.yml` we can instead just specify major.minor versions and have it automatically test against the latest available patch version.
